### PR TITLE
Fix download_sections parsing for API usage

### DIFF
--- a/yt_dlp/YoutubeDL.py
+++ b/yt_dlp/YoutubeDL.py
@@ -158,6 +158,8 @@ from .utils import (
     filesize_from_tbr,
     timetuple_from_msec,
     to_high_limit_path,
+    download_range_func,
+    parse_optional_ranges,
     traverse_obj,
     try_call,
     try_get,
@@ -620,6 +622,13 @@ class YoutubeDL:
         if params is None:
             params = {}
         self.params = params
+        if 'download_ranges' not in self.params and 'download_sections' in self.params:
+            self.params['download_ranges'] = self.params['download_sections']
+
+        if 'download_ranges' in self.params and not callable(self.params['download_ranges']):
+            chapters, ranges, from_url = parse_optional_ranges('--download-sections', self.params['download_ranges'], advanced=True)
+            self.params['download_ranges'] = download_range_func(chapters, ranges, from_url)
+
         self._ies = {}
         self._ies_instances = {}
         self._pps = {k: [] for k in POSTPROCESS_WHEN}

--- a/yt_dlp/__init__.py
+++ b/yt_dlp/__init__.py
@@ -53,6 +53,7 @@ from .utils import (
     match_filter_func,
     parse_bytes,
     parse_duration,
+    parse_optional_ranges,
     preferredencoding,
     read_batch_urls,
     read_stdin,
@@ -339,49 +340,8 @@ def validate_options(opts):
         opts.skip_download = None
         del opts.outtmpl['default']
 
-    def parse_chapters(name, value, advanced=False):
-        parse_timestamp = lambda x: float('inf') if x in ('inf', 'infinite') else parse_duration(x)
-        TIMESTAMP_RE = r'''(?x)(?:
-            (?P<start_sign>-?)(?P<start>[^-]+)
-        )?\s*-\s*(?:
-            (?P<end_sign>-?)(?P<end>[^-]+)
-        )?'''
-
-        chapters, ranges, from_url = [], [], False
-        for regex in value or []:
-            if advanced and regex == '*from-url':
-                from_url = True
-                continue
-            elif not regex.startswith('*'):
-                try:
-                    chapters.append(re.compile(regex))
-                except re.error as err:
-                    raise ValueError(f'invalid {name} regex "{regex}" - {err}')
-                continue
-
-            for range_ in map(str.strip, regex[1:].split(',')):
-                mobj = range_ != '-' and re.fullmatch(TIMESTAMP_RE, range_)
-                dur = mobj and [parse_timestamp(mobj.group('start') or '0'), parse_timestamp(mobj.group('end') or 'inf')]
-                signs = mobj and (mobj.group('start_sign'), mobj.group('end_sign'))
-
-                err = None
-                if None in (dur or [None]):
-                    err = 'Must be of the form "*start-end"'
-                elif not advanced and any(signs):
-                    err = 'Negative timestamps are not allowed'
-                else:
-                    dur[0] *= -1 if signs[0] else 1
-                    dur[1] *= -1 if signs[1] else 1
-                    if dur[1] == float('-inf'):
-                        err = '"-inf" is not a valid end'
-                if err:
-                    raise ValueError(f'invalid {name} time range "{regex}". {err}')
-                ranges.append(dur)
-
-        return chapters, ranges, from_url
-
-    opts.remove_chapters, opts.remove_ranges, _ = parse_chapters('--remove-chapters', opts.remove_chapters)
-    opts.download_ranges = download_range_func(*parse_chapters('--download-sections', opts.download_ranges, True))
+    opts.remove_chapters, opts.remove_ranges, _ = parse_optional_ranges('--remove-chapters', opts.remove_chapters)
+    opts.download_ranges = download_range_func(*parse_optional_ranges('--download-sections', opts.download_ranges, advanced=True))
 
     # Cookies from browser
     if opts.cookiesfrombrowser:

--- a/yt_dlp/utils/_utils.py
+++ b/yt_dlp/utils/_utils.py
@@ -3327,6 +3327,56 @@ def match_filter_func(filters, breaking_filters=None):
     return _match_func
 
 
+def parse_optional_ranges(name, value, *, advanced=False):
+    """Parse chapter/range filters used by remove/download sections options"""
+    parse_timestamp = lambda x: float('inf') if x in ('inf', 'infinite') else parse_duration(x)
+    TIMESTAMP_RE = r'''(?x)(?:
+        (?P<start_sign>-?)(?P<start>[^-]+)
+    )?\s*-\s*(?:
+        (?P<end_sign>-?)(?P<end>[^-]+)
+    )?'''
+
+    chapters, ranges, from_url = [], [], False
+    for raw_value in variadic(value or []):
+        if isinstance(raw_value, re.Pattern):
+            chapters.append(raw_value)
+            continue
+        if not isinstance(raw_value, str):
+            raise ValueError(f'invalid {name} value {raw_value!r}. Expected string or regex')
+
+        if advanced and raw_value == '*from-url':
+            from_url = True
+            continue
+
+        if not raw_value.startswith('*'):
+            try:
+                chapters.append(re.compile(raw_value))
+            except re.error as err:
+                raise ValueError(f'invalid {name} regex "{raw_value}" - {err}')
+            continue
+
+        for range_ in map(str.strip, raw_value[1:].split(',')):
+            mobj = range_ != '-' and re.fullmatch(TIMESTAMP_RE, range_)
+            dur = mobj and [parse_timestamp(mobj.group('start') or '0'), parse_timestamp(mobj.group('end') or 'inf')]
+            signs = mobj and (mobj.group('start_sign'), mobj.group('end_sign'))
+
+            err = None
+            if None in (dur or [None]):
+                err = 'Must be of the form "*start-end"'
+            elif not advanced and any(signs):
+                err = 'Negative timestamps are not allowed'
+            else:
+                dur[0] *= -1 if signs[0] else 1
+                dur[1] *= -1 if signs[1] else 1
+                if dur[1] == float('-inf'):
+                    err = '"-inf" is not a valid end'
+            if err:
+                raise ValueError(f'invalid {name} time range "{raw_value}". {err}')
+            ranges.append(dur)
+
+    return chapters, ranges, from_url
+
+
 class download_range_func:
     def __init__(self, chapters, ranges, from_info=False):
         self.chapters, self.ranges, self.from_info = chapters, ranges, from_info


### PR DESCRIPTION
## Summary
- share the logic that parses chapter and time-range options between the CLI and API
- normalize Python API parameters so download_sections strings become callable download_range_func instances

## Testing
- python - <<'PY'
import yt_dlp

_ = yt_dlp.YoutubeDL({'download_sections': '*1-2'})
PY
- python ../repro_api.py *(fails: ProxyError 403 when contacting YouTube)*

------
https://chatgpt.com/codex/tasks/task_e_68e146074adc832588a4ff07d26ed46a